### PR TITLE
WIP: Bump version

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=lokalise2
 pkgrel=2
-pkgver=2.6.3
+pkgver=2.6.4
 pkgdesc="Lokalise CLI v2 for lokalise.com."
 url="https://lokalise.com"
 arch=('x86_64')


### PR DESCRIPTION
Can no longer update.

Downloading does not work, as github requires the accept header to be set correctly: https://docs.github.com/en/rest/reference/repos#get-a-release-asset

But not all packets have that problem: https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=xray